### PR TITLE
Fix Non-date filters are not working

### DIFF
--- a/src/metabase/driver/cubejs/query_processor.clj
+++ b/src/metabase/driver/cubejs/query_processor.clj
@@ -248,7 +248,7 @@
   (let [filter  (:filter query)
         filters (if filter (parse-filter filter) nil)
         raw     (flatten (if (vector? filters) filters (if filters (conj [] filters) nil)))
-        optimized (optimize-datetime-filters raw)
+        optimized (reduce datetime-filter-optimizer [] raw)
         result  (filterv #(or (not (is-datetime-operator? (:operator %))) (and (is-datetime-operator? (:operator %)) (< (count (:values %)) 2))) optimized)]
     {:filters result}))
 


### PR DESCRIPTION
Non Date Filters were removed by optimize-datetime-filters. Fixed.

**Issue Reference this PR resolves**

Non-date filters are not working #54
