### PR TITLE
Added maximum Cube Js Limit Check

### DIFF
--- a/src/metabase/driver/cubejs/query_processor.clj
+++ b/src/metabase/driver/cubejs/query_processor.clj
@@ -270,9 +270,12 @@
 
 (defn- handle-limit
   [{:keys [limit]}]
-  (if-not (nil? limit)
-    {:limit limit}
-    nil))
+  ( let [limit-limit 50000]
+    (if-not (nil? limit)
+    {:limit (if (> limit limit-limit)
+      limit-limit
+      limit)}
+    nil)))
 
 ;;; ----------------------------------------------------- fields -----------------------------------------------------
 


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

When Downloading data in Metabase, metabase is adding their limit `absolute-max-results` which is 1048576 to query. 
Cube Js supports Limit up to 50000. So i added Limit Check which lowers requested limit to 50000.
